### PR TITLE
Add osb-eusvc.samsungqbe.com to SmartTV.txt

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -110,6 +110,7 @@ oempprd.samsungcloudsolution.net
 openapi.samsung.com
 osb-apps.samsungqbe.com
 osb-krsvc.samsungqbe.com
+osb-eusvc.samsungqbe.com
 osb.samsungqbe.com
 otnprd10.samsungcloudsolution.net
 otnprd11.samsungcloudsolution.net


### PR DESCRIPTION
There seems to be a version of "osb.samsungqbe.com" for every region. For me as a European user "osb-eusvc.samsungqbe.com" had to be added. The "kr"-version for Korea is already there, but I don't now about the US and other regions.