### PR TITLE
Add log-ingestion-eu.samsungacr.com to SmartTV.txt

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -98,6 +98,7 @@ log-1.samsungacr.com
 log-2.samsungacr.com
 log-3.samsungacr.com
 log-ingestion.samsungacr.com
+log-ingestion-eu.samsungacr.com
 log.internetat.tv
 multiscreen.samsung.com
 musicid.samsungcloudsolution.com


### PR DESCRIPTION
As for many "services" there seem to be regional variants. This adds the EU version of the ACR-log (Automatic Content Recognition).

Source (among others and my own experience): https://sbmueller.github.io/post/pihole/