### PR TITLE
Update Netflix default block list

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -196,11 +196,11 @@ xml.opera.com
 
 
 # Netflix
-# secure, api-global, ichnaea, and appboot break Netflix
+# secure, api-global, and appboot break Netflix
 #secure.netflix.com                   
 #api-global.netflix.com
-#ichnaea.netflix.com
 #appboot.netflix.com
+ichnaea.netflix.com
 customerevents.netflix.com
 nrdp.nccp.netflix.com
 


### PR DESCRIPTION
`ichnaea.netflix.com` doesn't seem to break Netflix anymore. I've had it blocked for over a week and Netflix still works on all the devices on my network. If someone else could confirm before this PR gets merged that'd be great!