### PR TITLE
Remove samsung authentication domains

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -94,7 +94,6 @@ ad.samsungadhub.com
 ads.samsungads.com
 amauthprd.samsungcloudsolution.com
 api-hub.samsungyosemite.com
-auth.samsungosp.com
 az43064.vo.msecnd.net
 cdn.samsungcloudsolution.com
 cdn.samsungcloudsolution.net
@@ -152,7 +151,6 @@ samsungacr.com
 samsungadhub.com
 samsungcloudsolution.com
 samsungcloudsolution.net
-samsungosp.com
 samsungotn.net
 samsungqbe.com
 samsungrm.net

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -94,6 +94,7 @@ ad.samsungadhub.com
 ads.samsungads.com
 amauthprd.samsungcloudsolution.com
 api-hub.samsungyosemite.com
+#auth.samsungosp.com // if blocked, samsung accounts will fail to authenticate
 az43064.vo.msecnd.net
 cdn.samsungcloudsolution.com
 cdn.samsungcloudsolution.net
@@ -151,6 +152,7 @@ samsungacr.com
 samsungadhub.com
 samsungcloudsolution.com
 samsungcloudsolution.net
+#samsungosp.com
 samsungotn.net
 samsungqbe.com
 samsungrm.net


### PR DESCRIPTION
Hi there,

I don't know if this is intentional, but blocking `samsungosp.com` related domains will BREAK user authentication (i.e. logging into Samsung account)

I discovered this by accident with the similar issue:
https://imgur.com/gallery/9FxJ5

```
auth.samsungosp.com
us-auth2.samsungosp.com
```

People seem to also complain here:
https://www.reddit.com/r/pihole/comments/c8u0la/comment/esptp24

If this was not intentional, could you please unblock these domains by merging this pull request?
Otherwise, ignore this PR.

P.S. the same domains are also present in here:
https://github.com/Akamaru/Pi-Hole-Lists/pull/3

Thank you