### PR TITLE
Removed static-cdn.jtvnw.net

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -62,7 +62,6 @@ flingo.tv
 sonybivstatic-a.akamaihd.net
 ssm1.internet.sony.tv
 facemap.foldlife.net
-static-cdn.jtvnw.net
 bdcore-apr-lb.bda.ndmdhs.com
 
 


### PR DESCRIPTION
static-cdn.jtvnw.net is part of the CDN for twitch.tv and this blocked legit traffic for emojis, icons and static preview images.