### PR TITLE
Pretty big update

### DIFF
--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.6]
 ! Title: Perflyst and Dandelion Sprout's Smart-TV Blocklist for AdGuard Home
-! Version: 11January2020v3-Beta
+! Version: 11January2020v4
 ! Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 ! Please help to collect domains!
 ! It could occur that the TV fails to receive new updates, or that other apps or services no longer work. Please report such an incident.
@@ -231,20 +231,3 @@
 ||logs1409.xiti.com^
 ||tracksrv.zdf.de^
 ||settings.crashlytics.com^
-
-! —————————————————————————————————————————————————————————————
-
-! Entries based on Game Console Adblock List (https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt), which the owner has donated to this project and relicenced into MIT to fit with the rest of this list
-
-! PlayStation 3
-! Ads
-||nsx-e.np.dl.playstation.net^
-! What's New
-||mercury.dl.playstation.net^
-! PlayStation Store Preview
-||nsx.np.dl.playstation.net^
-
-! Nintendo 3DS
-! Blocks the "Theme Shop", with the intention of preventing the annoying pink dot in the upper left of the Home Menu from reappearing all the time.
-! The entry is deactivated by default, as it breaks the "Theme Shop" from being visited at all while the entry is active.
-!||npdl.cdn.nintendowifi.net^

--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -1,0 +1,210 @@
+[Adblock Plus 3.6]
+! Title: Perflyst and Dandelion Sprout's SmartTV Blocklist for AdGuard Home
+! Version: 09January2020v1-Beta
+! Description: This is a blocklist to block smart-TVs sending metadata back home.
+! Please help to collect domains!
+! It could occur that the TV fails to receive new updates or that other services no longer work. Please report such an incident.
+
+! Panasonic Viera & panny tv
+||cert-test.sandbox.google.com^
+
+||myhomescreen.tv^
+! If domains below are blocked, unable to use smarttv apps e.g. Netflix, AmazonVideo as TV calls home for connection check
+@@||mhc-ajax-eu.myhomescreen.tv^
+@@||mhc-xpana-eu.myhomescreen.tv^
+
+!vcs.vdspf.com  //  if blocked, notified of new firmware but unable to download/install
+||x2.vindicosuite.com^
+
+! Sony Bravia
+! needed for applications
+! needed for applications, if blocked error "no internet connection"
+!applicast.ga.sony.net
+!portal.store.sonyentertainmentnetwork.com
+||ad8641f3cff742de893d919add74c2bb.ssm1.internet.sony.tv^
+||ad8641f3cff742de893d919add74c2bb.ssm2.internet.sony.tv^
+||api-mf1.meta.ndmdhs.com^
+||b02.black.ndmdhs.com^
+||bravia.dl.playstation.net^
+||call.me.sel.sony.com^
+||flingo.tv^
+||sonybivstatic-a.akamaihd.net^
+||ssm1.internet.sony.tv^
+||facemap.foldlife.net^
+||bdcore-apr-lb.bda.ndmdhs.com^
+
+! LG
+||ad.lgappstv.com^
+||ibis.lgappstv.com^
+||lgad.cjpowercast.com.edgesuite.net^
+! ngfts.lge.com # blocks thumbnails from loading in the LG Content Store
+||smartclip.com^
+||smartclip.net^
+||smartshare.lgtvsdp.com^
+||ad.lgsmartad.com^
+||ibs.lgappstv.com^
+||info.lgsmartad.com^
+||lgtvsdp.com^
+||rdx2.lgtvsdp.com^
+||yumenetworks.com^
+! For TVs that try to connect to several garbled letter combinations
+/^[a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z]?[a-z]?[a-z]?[a-z]?[a-z]?$/
+
+! Philips
+!deviceportal.nettvservices.com # needed for apps
+!epg.corio.com # needed for apps
+||legacyportal.nettvservices.com^
+||nettv.corio.com^
+!www.ecdinterface.philips.com # Philips Hue Bridge
+||ad.nettvservices.com^
+
+! Samsung
+||abtauthprd.samsungcloudsolution.com^
+||acr0.samsungcloudsolution.com^
+||ad.samsungadhub.com^
+||ads.samsungads.com^
+||amauthprd.samsungcloudsolution.com^
+||api-hub.samsungyosemite.com^
+!auth.samsungosp.com // if blocked, samsung accounts will fail to authenticate
+||az43064.vo.msecnd.net^
+!cdn.samsungcloudsolution.com # system update check on Samsung UE40F5500
+||cdn.samsungcloudsolution.net^
+||configprd.samsungcloudsolution.net^
+||Coordinator-Production-28516768.us-east-1.elb.amazonaws.com^
+||cpu.samsungelectronics.com^
+||d179kwmlpc4o47.cloudfront.net^
+||d1jwpcr0q4pcq0.cloudfront.net^
+||d1oxlq5h9kq8q5.cloudfront.net^
+||d2tnx644ijgq6i.cloudfront.net^
+||d3mjsomixevyw7.cloudfront.net^
+||d37ju0xanoz6gh.cloudfront.net^
+||dev-multiscreen.samsung.com^
+||device-metrics-us.amazon.com^
+||fkp.samsungcloudsolution.com^
+||fkp.samsungcloudsolution.net^
+||game.internetat.tv^
+||gld.samsungosp.com^
+||gpm.samsungqbe.com^
+||i-stream.pl^
+||infolink.pavv.co.kr^
+!infolink.pavv.co.kr # Needed for appstore and login on Samsung UE40F5500
+||lcprd1.samsungcloudsolution.net^
+||log-1.samsungacr.com^
+||log-2.samsungacr.com^
+||log-3.samsungacr.com^
+||log-ingestion.samsungacr.com^
+||log-ingestion-eu.samsungacr.com^
+||log.internetat.tv^
+||multiscreen.samsung.com^
+||musicid.samsungcloudsolution.com^
+||notice.samsungcloudsolution.com^
+||noticecdn.samsungcloudsolution.com^
+||noticefile.samsungcloudsolution.com^
+||ns11.whois.co.kr^
+||oempprd.samsungcloudsolution.com^
+||oempprd.samsungcloudsolution.net^
+||openapi.samsung.com^
+||osb-apps.samsungqbe.com^
+||osb-krsvc.samsungqbe.com^
+||osb-eusvc.samsungqbe.com^
+||osb.samsungqbe.com^
+||otnprd10.samsungcloudsolution.net^
+||otnprd11.samsungcloudsolution.net^
+||otnprd8.samsungcloudsolution.net^
+||otnprd9.samsungcloudsolution.net^
+||pavv.co.kr^
+||pipeaota.com^
+||premium-videos.telly.com^
+||prov.samsungcloudsolution.com^
+||rd.samsungadhub.com^
+||rwww.samsungotn.net^
+||samsungacr.com^
+||samsungadhub.com^
+|samsungcloudsolution.com^
+|samsungcloudsolution.net^
+!samsungosp.com
+!samsungotn.net # system update check on Samsung UE65RU7455
+||samsungqbe.com^
+||samsungrm.net^
+||sas.samsungcloudsolution.com^
+||sca.samsung.com^
+||sso.internetat.tv^
+||syncplusconfig.s3.amazonaws.com^
+||targeted-config-test.samsungacr.com^
+||test.samsungrm.net^
+!time.samsungcloudsolution.com // if blocked, services like Plex, YouTube and Amazon Video not working anymore on some Samsung TV's
+||us-api.samsungyosemite.com^
+||vd.emp.prd.s3.amazonaws.com^
+||vdterms.samsungcloudsolution.com^
+||www.samsungotn.net^
+||www.samsungrm.net^
+||samsungelectronics.com^
+||apu.samsungelectronics.com^
+||bpu.samsungelectronics.com^
+||dpu.samsungelectronics.com^
+||kpu.samsungelectronics.com^
+||upu.samsungelectronics.com^
+||zpu.samsungelectronics.com^
+||xpu.samsungelectronics.com^
+||ypu.samsungelectronics.com^
+||vd.contents.prod.eu.s3.amazonaws.com^
+||log-ingestion-eu.samsungacr.com^
+||osb-ussvc.samsungqbe.com^
+||otn.samsungcloudcdn.com^
+
+! HBBTV
+||hbbtv.smartclip.net^
+||hbbtv-1.eurosport.com^
+||hbbtv-extern-fe01.sim-technik.de^
+||hbbtv-track.redbutton.de^
+||hbbtv.*.de^
+||hbbtv01p.anixe.net^
+||hbbtvapp.sonnenklar.tv^
+||stats.hbbtv.smartclip.net^
+||p-hbbtv.superrtl.de^
+
+! Other useless connections from Smart-TV
+||ad.71i.de^
+||api.nfl.com^
+! apicache.vudu.com # needed for vudu app see issue22
+||cdn.smartclip.net^
+||cdns-content.dzcdn.net^
+||cert-test.sandbox.google.com^
+||database01p.anixe.net^
+||de.ioam.de^
+!drscdn.500px.org # blocks 500px on desktop
+||geo.opera.com^
+||googleads.g.doubleclick.net^
+! itv.ard.de # ARD media lib - HBBTV 
+||nbc-jite.nbcuni.com^
+||redbutton-adproxy-lb-prod.redbutton.de^
+||redbutton-lb-prod.redbutton.de^
+||redbutton.sim-technik.de^
+||script.ioam.de^
+||start.digitaltext.rtl.de^
+||stats-irl.sxp.smartclip.net^
+||tv-static.scdn.co^
+||tv.deezer.com^
+||xml.opera.com^
+
+! Netflix
+! secure, api-global, and appboot break Netflix
+!secure.netflix.com                   
+!api-global.netflix.com
+!appboot.netflix.com
+||ichnaea.netflix.com^
+||customerevents.netflix.com^
+||nrdp.nccp.netflix.com^
+
+! Spotify
+||api-tv.spotify.com^
+
+! Hulu
+||api.distribution.hulu.com^
+
+! Sharp Smart TV using Opera OS (thanks to sml156)
+! time-a.timefreq.bldrdoc.gov          # probably not a good idea to block this one
+! api.accuweather.com                  # probably not a good idea to block this one
+
+! These may be needed for software/firmware updates, not sure if it's one or both but the first one tries thousands of times a day to connect.
+||api.*.hismarttv.com^

--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.6]
 ! Title: Perflyst and Dandelion Sprout's SmartTV Blocklist for AdGuard Home
-! Version: 11January2020v1-Beta
+! Version: 11January2020v2-Beta
 ! Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 ! Please help to collect domains!
 ! It could occur that the TV fails to receive new updates, or that other apps or services no longer work. Please report such an incident.
@@ -243,3 +243,8 @@
 ||mercury.dl.playstation.net^
 ! PlayStation Store Preview
 ||nsx.np.dl.playstation.net^
+
+! Nintendo 3DS
+! Blocks the "Theme Shop", with the intention of preventing the annoying pink dot in the upper left of the Home Menu from reappearing all the time.
+! The entry is deactivated by default, as it breaks the "Theme Shop" from being visited at all while the entry is active.
+!||npdl.cdn.nintendowifi.net^

--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 3.6]
-! Title: Perflyst and Dandelion Sprout's SmartTV Blocklist for AdGuard Home
-! Version: 11January2020v2-Beta
+! Title: Perflyst and Dandelion Sprout's Smart-TV Blocklist for AdGuard Home
+! Version: 11January2020v3-Beta
 ! Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 ! Please help to collect domains!
 ! It could occur that the TV fails to receive new updates, or that other apps or services no longer work. Please report such an incident.

--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -1,4 +1,3 @@
-[Adblock Plus 3.6]
 ! Title: Perflyst and Dandelion Sprout's Smart-TV Blocklist for AdGuard Home
 ! Version: 11January2020v4
 ! Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.

--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 3.6]
 ! Title: Perflyst and Dandelion Sprout's SmartTV Blocklist for AdGuard Home
-! Version: 09January2020v1-Beta
-! Description: This is a blocklist to block smart-TVs sending metadata back home.
+! Version: 09January2020v2-Beta
+! Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 ! Please help to collect domains!
 ! It could occur that the TV fails to receive new updates or that other services no longer work. Please report such an incident.
 
@@ -208,3 +208,25 @@
 
 ! These may be needed for software/firmware updates, not sure if it's one or both but the first one tries thousands of times a day to connect.
 ||api.*.hismarttv.com^
+
+! ————————————————————————————————————————————————
+
+! Amazon Fire Stick (First-party)
+||device-messaging-na.amazon.com^
+||devicemessaging.us-east-1.amazon.com^
+||fls-*.amazon.com^
+||mads-eu.amazon.com^
+||mas-sdk.amazon.com^
+||mas-ext.amazon.com^
+||aax-eu.amazon-adsystem.com^
+||msh.amazon.co.uk^
+||amazonadsi-a.akamaihd.net^
+||mobileanalytics.us-east-1.amazonaws.com^
+
+! Amazon Fire Stick (Third-party)
+||config.ioam.de^
+||de.ioam.de^
+||secure-eu.imrworldwide.com^
+||logs1409.xiti.com^
+||tracksrv.zdf.de^
+||settings.crashlytics.com^

--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -45,7 +45,6 @@
 ||ibs.lgappstv.com^
 ||info.lgsmartad.com^
 ||lgtvsdp.com^
-||rdx2.lgtvsdp.com^
 ||yumenetworks.com^
 ! For TVs that try to connect to several garbled letter combinations
 /^[a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z]?[a-z]?[a-z]?[a-z]?[a-z]?$/
@@ -184,7 +183,7 @@
 ||start.digitaltext.rtl.de^
 ||stats-irl.sxp.smartclip.net^
 ||tv-static.scdn.co^
-||tv.deezer.com^
+!tv.deezer.com # Breaks Deezer's smart-TV apps.
 ||xml.opera.com^
 
 ! Netflix

--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -1,15 +1,15 @@
 [Adblock Plus 3.6]
 ! Title: Perflyst and Dandelion Sprout's SmartTV Blocklist for AdGuard Home
-! Version: 09January2020v2-Beta
+! Version: 11January2020v1-Beta
 ! Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 ! Please help to collect domains!
-! It could occur that the TV fails to receive new updates or that other services no longer work. Please report such an incident.
+! It could occur that the TV fails to receive new updates, or that other apps or services no longer work. Please report such an incident.
 
-! Panasonic Viera & panny tv
+! Panasonic Viera & Panny TV
 ||cert-test.sandbox.google.com^
 
 ||myhomescreen.tv^
-! If domains below are blocked, unable to use smarttv apps e.g. Netflix, AmazonVideo as TV calls home for connection check
+! If domains below are blocked, unable to use smart-TV apps like Netflix, Amazon Video, etc. as TV calls home for connection check
 @@||mhc-ajax-eu.myhomescreen.tv^
 @@||mhc-xpana-eu.myhomescreen.tv^
 
@@ -40,10 +40,8 @@
 ! ngfts.lge.com # blocks thumbnails from loading in the LG Content Store
 ||smartclip.com^
 ||smartclip.net^
-||smartshare.lgtvsdp.com^
-||ad.lgsmartad.com^
+||lgsmartad.com^
 ||ibs.lgappstv.com^
-||info.lgsmartad.com^
 ||lgtvsdp.com^
 ||yumenetworks.com^
 ! For TVs that try to connect to several garbled letter combinations
@@ -85,7 +83,6 @@
 ||gld.samsungosp.com^
 ||gpm.samsungqbe.com^
 ||i-stream.pl^
-||infolink.pavv.co.kr^
 !infolink.pavv.co.kr # Needed for appstore and login on Samsung UE40F5500
 ||lcprd1.samsungcloudsolution.net^
 ||log-1.samsungacr.com^
@@ -161,6 +158,9 @@
 ||hbbtvapp.sonnenklar.tv^
 ||stats.hbbtv.smartclip.net^
 ||p-hbbtv.superrtl.de^
+@@||hbbtv.zdf.de^
+@@||hbbtv.prosieben.de^
+@@||hbbtv.redbutton.de^
 
 ! Other useless connections from Smart-TV
 ||ad.71i.de^
@@ -208,9 +208,11 @@
 ! These may be needed for software/firmware updates, not sure if it's one or both but the first one tries thousands of times a day to connect.
 ||api.*.hismarttv.com^
 
-! ————————————————————————————————————————————————
+! —————————————————————————————————————————————————————————————
 
-! Amazon Fire Stick (First-party)
+! Entries based on https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt
+
+! Amazon Fire TV (First-party)
 ||device-messaging-na.amazon.com^
 ||devicemessaging.us-east-1.amazon.com^
 ||fls-*.amazon.com^
@@ -222,10 +224,22 @@
 ||amazonadsi-a.akamaihd.net^
 ||mobileanalytics.us-east-1.amazonaws.com^
 
-! Amazon Fire Stick (Third-party)
+! Amazon Fire TV (Third-party)
 ||config.ioam.de^
 ||de.ioam.de^
 ||secure-eu.imrworldwide.com^
 ||logs1409.xiti.com^
 ||tracksrv.zdf.de^
 ||settings.crashlytics.com^
+
+! —————————————————————————————————————————————————————————————
+
+! Entries based on Game Console Adblock List (https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt), which the owner has donated to this project and relicenced into MIT to fit with the rest of this list
+
+! PlayStation 3
+! Ads
+||nsx-e.np.dl.playstation.net^
+! What's New
+||mercury.dl.playstation.net^
+! PlayStation Store Preview
+||nsx.np.dl.playstation.net^

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -1,4 +1,4 @@
-# Title: Perflyst's SmartTV Blocklist for Pi-hole
+# Title: Perflyst's Smart-TV Blocklist for Pi-hole
 # Version: 11January2020v1
 # Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 # Please help with collecting domains!

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -1,6 +1,6 @@
 # Title: Perflyst's SmartTV Blocklist for Pi-hole
-# Version: 09January2020v1
-# Description: This is a blocklist to block smart-TVs sending metadata back home.
+# Version: 09January2020v2
+# Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 # Please help with collecting domains!
 # It could occur that the TV fails to receive new updates or that other services no longer work. Please report such an incident.
 # Make sure to also use the extra RegEx list at https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/regex.list, which helps remove regional LG ad domains among other things.

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -1,8 +1,8 @@
 # Title: Perflyst's SmartTV Blocklist for Pi-hole
-# Version: 09January2020v2
+# Version: 11January2020v1
 # Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 # Please help with collecting domains!
-# It could occur that the TV fails to receive new updates or that other services no longer work. Please report such an incident.
+# It could occur that the TV fails to receive new updates, or that other apps or services no longer work. Please report such an incident.
 # Make sure to also use the extra RegEx list at https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/regex.list, which helps remove regional LG ad domains among other things.
 
 # Panasonic Viera & panny tv
@@ -101,7 +101,7 @@ amauthprd.samsungcloudsolution.com
 api-hub.samsungyosemite.com
 #auth.samsungosp.com // if blocked, samsung accounts will fail to authenticate
 az43064.vo.msecnd.net
-#cdn.samsungcloudsolution.com # ystem update check on Samsung UE40F5500
+#cdn.samsungcloudsolution.com # System update check on Samsung UE40F5500
 cdn.samsungcloudsolution.net
 configprd.samsungcloudsolution.net
 Coordinator-Production-28516768.us-east-1.elb.amazonaws.com
@@ -192,15 +192,13 @@ hbbtv-1.eurosport.com
 hbbtv-extern-fe01.sim-technik.de
 hbbtv-track.redbutton.de
 hbbtv.kabeleins.de
-hbbtv.prosieben.de
+#hbbtv.prosieben.de # Blocks ProSieben apps from starting.
 hbbtv.qvc.de
-hbbtv.redbutton.de
-hbbtv.redbutton.de
+#hbbtv.redbutton.de # Blocks ZDF & ProSieben apps from starting.
 hbbtv.rtl2.de
 hbbtv.sat1.de
 hbbtv.sixx.de
-hbbtv.zdf.de
-hbbtv.zdf.de
+#hbbtv.zdf.de # Blocks ZDF apps from starting.
 hbbtv01p.anixe.net
 hbbtvapp.sonnenklar.tv
 scheduler.hbbtv.smartclip.net

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -1,6 +1,9 @@
-# This is a blocklist to block smart tv's sending meta data at home.
-# Please help to collect domains!
-# It could be that the TV does not receive any more updates or other services no longer work. Please report such an incident.
+# Title: Perflyst's SmartTV Blocklist for Pi-hole
+# Version: 09January2020v1
+# Description: This is a blocklist to block smart-TVs sending metadata back home.
+# Please help with collecting domains!
+# It could occur that the TV fails to receive new updates or that other services no longer work. Please report such an incident.
+# Make sure to also use the extra RegEx list at https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/regex.list, which helps remove regional LG ad domains among other things.
 
 # Panasonic Viera & panny tv
 0077777700140002.myhomescreen.tv
@@ -36,11 +39,11 @@ usage-us-fy2018.myhomescreen.tv
 usage-us-fy2019.myhomescreen.tv
 
 
-#mhc-ajax-eu.myhomescreen.tv  //  if blocked, unable to use smarttv apps e.g. Netflix, AmazonVideo as TV calls home for connection check
+#mhc-ajax-eu.myhomescreen.tv  //  if blocked, unable to use smart-TV apps like Netflix, Amazon Video, etc., as TV calls home for connection check
 mhc-ajax-us.myhomescreen.tv
 mhc-sec-eu.myhomescreen.tv
 mhc-sec-us.myhomescreen.tv
-#mhc-xpana-eu.myhomescreen.tv  //  if blocked, unable to use smarttv apps e.g. Netflix, AmazonVideo as TV calls home for connection check
+#mhc-xpana-eu.myhomescreen.tv  //  if blocked, unable to use smart-TV apps like Netflix, Amazon Video, etc., as TV calls home for connection check
 mhc-xpana-us.myhomescreen.tv
 #vcs.vdspf.com  //  if blocked, notified of new firmware but unable to download/install
 x2.vindicosuite.com
@@ -103,7 +106,7 @@ cdn.samsungcloudsolution.net
 configprd.samsungcloudsolution.net
 Coordinator-Production-28516768.us-east-1.elb.amazonaws.com
 cpu.samsungelectronics.com
-d179kwmlpc4o47.cloudfront.ne
+d179kwmlpc4o47.cloudfront.net
 d179kwmlpc4o47.cloudfront.net
 d1jwpcr0q4pcq0.cloudfront.net
 d1oxlq5h9kq8q5.cloudfront.net
@@ -118,7 +121,6 @@ game.internetat.tv
 gld.samsungosp.com
 gpm.samsungqbe.com
 i-stream.pl
-infolink.pavv.co.k
 #infolink.pavv.co.kr # Needed for appstore and login on Samsung UE40F5500
 lcprd1.samsungcloudsolution.net
 log-1.samsungacr.com
@@ -210,7 +212,7 @@ hbbtv.3sat.de
 # Other useless connections from Smart-TV
 ad.71i.de
 api.nfl.com
-# apicache.vudu.com # needed for vudu app see issue22
+# apicache.vudu.com # needed for Vudu's app, see issue22
 cdn.smartclip.net
 cdns-content.dzcdn.net
 cert-test.sandbox.google.com
@@ -228,9 +230,8 @@ script.ioam.de
 start.digitaltext.rtl.de
 stats-irl.sxp.smartclip.net
 tv-static.scdn.co
-tv.deezer.com
+#tv.deezer.com # Breaks Deezer's smart-TV apps.
 xml.opera.com
-
 
 # Netflix
 # secure, api-global, and appboot break Netflix

--- a/regex.list
+++ b/regex.list
@@ -1,5 +1,5 @@
 # Title: Perflyst's SmartTV Blocklist for Pi-hole - RegEx extension
-# Version: 11January2020v1-Alpha
+# Version: 11January2020v2
 
 # LG
 (^|\.)ibs\.lgappstv\.com

--- a/regex.list
+++ b/regex.list
@@ -1,13 +1,12 @@
 # Title: Perflyst's SmartTV Blocklist for Pi-hole - RegEx extension
-# Version: 09January2020v2-Alpha
+# Version: 11January2020v1-Alpha
 
 # LG
 (^|\.)ibs\.lgappstv\.com
-(^|\.)info\.lgsmartad\.com
+(^|\.)lgsmartad\.com
 (^|\.)lgtvsdp\.com
 ^[a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z]?[a-z]?[a-z]?[a-z]?[a-z]?$
 
 # Other
 (^|\.)myhomescreen\.tv$
 ^api\..*\.hismarttv\.com$
-^hbbtv\..*\.de$

--- a/regex.list
+++ b/regex.list
@@ -1,6 +1,13 @@
-# everything with regex
+# Title: Perflyst's SmartTV Blocklist for Pi-hole - RegEx extension
+# Version: 09January2020v1-Alpha
 
+# LG
+(^|\.)ibs\.lgappstv\.com
+(^|\.)info\.lgsmartad\.com
+(^|\.)rdx2\.lgtvsdp\.com
+^[a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z]?[a-z]?[a-z]?[a-z]?[a-z]?$
 
+# Other
 (^|\.)myhomescreen\.tv$
-(^|\.)lgtvsdp\.com$
-(^|\.)ad\.lgsmartad\.com$
+^api\..*\.hismarttv\.com$
+^hbbtv\..*\.de$

--- a/regex.list
+++ b/regex.list
@@ -1,10 +1,10 @@
 # Title: Perflyst's SmartTV Blocklist for Pi-hole - RegEx extension
-# Version: 09January2020v1-Alpha
+# Version: 09January2020v2-Alpha
 
 # LG
 (^|\.)ibs\.lgappstv\.com
 (^|\.)info\.lgsmartad\.com
-(^|\.)rdx2\.lgtvsdp\.com
+(^|\.)lgtvsdp\.com
 ^[a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z][a-z]?[a-z]?[a-z]?[a-z]?[a-z]?$
 
 # Other


### PR DESCRIPTION
Okay, so the situation is that AdGuard Home is now seemingly doing [an open rollcall for new lists to include in stock installations](https://github.com/AdguardTeam/AdGuardHome/issues/1325). Additionally, I became aware of some problems involving the Deezer smart-TV app and of a way to block LG TVs' ridiculous connection attempts to garbled domains, so I went for a twofer, and decided to fix the entries in your Pi-hole list version and to create an AGH list version on top of that, spending three days on the preparations.

Complete changelog:
* Created an AdGuard Home list version based on not only your smart-TV list, but also your Amazon Fire TV list and select entries from my game console list.
* Attempted to deal with https://github.com/Perflyst/PiHoleBlocklist/issues/29 to the best of my ability (Norway does not use Hbb in any way, so I am not able to test the feasibility of Hbb entries *at all*.)
* Removed some duplicates and misspelled domains.
* Commented out `tv.deezer.com`, as it causes an error message when starting up Deezer's TV app.
* Wrote a RegEx to attempt to take care of LG garbled connection attempts. Although they're from a purely technical standpoint not dangerous, it does look super-weird. (Image below this paragraph.)
* Created metadata at the top of the Pi-hole and Pi-hole RegEx list versions.
* Some grammar improvements.

![image](https://user-images.githubusercontent.com/22780683/72203213-3abe9380-3469-11ea-8f87-52b92f3df81d.png)

I understand it as such that you have virtually zero experience with AdGuard Home, or for that matter with writing lists for ordinary adblockers like uBlock Origin, so I will volunteer to help you out with the AGH list version to begin with if you ever need my help with it for anything whatsoever, in exchange for being credited in its metadata. The biggest difference is that AGH can do blacklisting, whitelisting and RegEx in the same list, which I understand it as such that Pi-hole can't.

I took a considerably more conversative P-H→AGH conversion approach than I did in https://github.com/Perflyst/PiHoleBlocklist/issues/26, especially when it came to the Samsung entries, if that helps sweeten my proposal somewhat.

Should this pull request become accepted, I would give **very** warm recommendations to the AGH team to include the AGH list version in it, although I do not have the final say on their decisions.