### PR TITLE
Commented out  nrdp.nccp.netflix.com

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -237,9 +237,10 @@ xml.opera.com
 #secure.netflix.com                   
 #api-global.netflix.com
 #appboot.netflix.com
+#nrdp.nccp.netflix.com
 ichnaea.netflix.com
 customerevents.netflix.com
-nrdp.nccp.netflix.com
+
 
 # Spotify
 api-tv.spotify.com

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -237,6 +237,7 @@ xml.opera.com
 #secure.netflix.com                   
 #api-global.netflix.com
 #appboot.netflix.com
+# Netflix playback fails on Humax DTR-T2100 (YouView) STB
 #nrdp.nccp.netflix.com
 ichnaea.netflix.com
 customerevents.netflix.com


### PR DESCRIPTION
Netflix displays the error "We are having difficulty playing this title" 

Error appears within Nextflix app on STB when clicking play. Whitelisting resolves error, reproduces when white-list entry is removed.