### PR TITLE
Whitelist b-graph.facebook.com

### DIFF
--- a/android-tracking.txt
+++ b/android-tracking.txt
@@ -7,7 +7,7 @@
 
 # Facebook
 # graph.facebook.com # needed for facebook groups
-b-graph.facebook.com
+# b-graph.facebook.com # needed for facebook pages manager
 a-graph.facebook.com
 graph.instagram.com
 b-api.facebook.com


### PR DESCRIPTION
Heya! Got a quick whitelist addition for you: `b-graph.facebook.com`

This domain is required for Facebook Pages Manager to be able to login.