### PR TITLE
Update SmartTV-AGH.txt

### DIFF
--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -104,6 +104,7 @@
 |samsungcloudsolution.com^
 |samsungcloudsolution.net^
 ||samsungqbe.com^
+@@||osb.samsungqbe.com^ # Re-enable control by Google Home (tested on 2018-era UN55NU8000)
 ||samsungrm.net^
 ||sas.samsungcloudsolution.com^
 ||sca.samsung.com^


### PR DESCRIPTION
Permit some Samsung TVs to be controlled by Google Home. Tested on UN55NU8000 (2018).