### PR TITLE
Block Toshiba TV telemetry & tracking

### DIFF
--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -234,6 +234,13 @@
 ! Yamaha AV receivers
 !||avpro.global.yamaha.com^ # Blocks system updates on RX-V685
 
+! Toshiba
+||events.cid.samba.tv^
+||platform.cid.samba.tv^
+||file2fxm.azureedge.net^
+||7345023508.fxmconnect.com^
+||7345023508.fxm9485766783.com^
+
 ! —————————————————————————————————————————————————————————————
 
 ! Entries based on https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -319,3 +319,10 @@ a1.resources.foxtel.com.au
 
 # Yamaha AV receivers
 #avpro.global.yamaha.com # Blocks system updates on RX-V685
+
+# Toshiba
+events.cid.samba.tv
+platform.cid.samba.tv
+file2fxm.azureedge.net
+7345023508.fxmconnect.com
+7345023508.fxm9485766783.com


### PR DESCRIPTION
This change requires proper router configuration to be trully effective, because the OS on this brand tries to avoid blocking with hard coded DNS server. The router has to block these requests or redirect them to Pi-hole.