### PR TITLE
2 samba.tv

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -80,6 +80,9 @@ sonybivstatic-a.akamaihd.net
 facemap.foldlife.net
 bdcore-apr-lb.bda.ndmdhs.com
 tvsideviewandroidv2-cfgdst-ore-pro.bda.ndmdhs.com
+api.cid.samba.tv
+#platform.cid.samba.tv #See Toshiba
+preferences.cid.samba.tv
 
 # LG
 ad.lgappstv.com


### PR DESCRIPTION
Even disabled on Sony interface, there is a connection every FIVE minutes!
One was already defined for Toshiba TV

It connects also to several *.netflix.com and *.nflximg.com but I don't use that crap...
I was able to block them with https://nextdns.io/?from=98ctfnjk