### PR TITLE
Allow users to play fantasy football on NFL App

### DIFF
--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -167,7 +167,7 @@
 ||ad.71i.de^
 ||adv.ettoday.net^
 ||advertising.com^
-||api.nfl.com^
+!||api.nfl.com^ # Needed for NFL Fantasy Football App
 ! apicache.vudu.com # Needed for Vudu app; https://github.com/Perflyst/PiHoleBlocklist/issues/22
 !||cdns-content.dzcdn.net^ # https://oisd.nl/excludes.php?w=cdns-content.dzcdn.net
 ||cert-test.sandbox.google.com^

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -257,7 +257,7 @@ hbbtv.3sat.de
 ad.71i.de
 adv.ettoday.net
 advertising.com
-api.nfl.com
+#api.nfl.com # required for NFL Fantasy Football App
 #apicache.vudu.com # needed for Vudu's app, see issue22
 cdn.smartclip.net
 #cdns-content.dzcdn.net # https://oisd.nl/excludes.php?w=cdns-content.dzcdn.net


### PR DESCRIPTION
### Link to Issue
#110

### Description of Issue
When using this list, if you are connected to the network, a user would be unable to use the NFL Fantasy Football App.

### Solution
Comment line out for blocking `api.nfl.com` since it is a required call for the application.

### Commits
* fix(#110): Update SmartTV.txt
Allow users to use the NFL Fantasy Football mobile application.