### PR TITLE
Block Android TV home screen ads

### DIFF
--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -271,3 +271,7 @@
 ||tracking.intl.miui.com^
 !||data.mistat.intl.xiaomi.com^ # https://oisd.nl/excludes.php?w=data.mistat.intl.xiaomi.com
 ||sdkconfig.ad.intl.xiaomi.com^
+
+! Android TV (including Nvidia Shield TV)
+||androidtvchannels-pa.googleapis.com^
+||androidtvwatsonfe-pa.googleapis.com^

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -343,3 +343,7 @@ mitv.tracking.intl.miui.com
 tracking.intl.miui.com
 data.mistat.intl.xiaomi.com
 sdkconfig.ad.intl.xiaomi.com
+
+# Android TV (including Nvidia Shield TV)
+androidtvchannels-pa.googleapis.com
+androidtvwatsonfe-pa.googleapis.com


### PR DESCRIPTION
A recent updated broughts ads to the home screen of Android TV devices like the Nvidia Shield TV: https://www.techradar.com/news/nvidia-shield-tv-users-are-angry-about-ads-but-can-you-get-around-them

These entries disable the ads.