### PR TITLE
Add alexa analytics domain

### DIFF
--- a/AmazonFireTV.txt
+++ b/AmazonFireTV.txt
@@ -21,6 +21,7 @@ mobileanalytics.us-east-1.amazonaws.com
 #cortana-gateway.amazon.com
 #api.amazonalexa.com
 #avs.eu.amazonalexa.com
+d3p8zr0ffa9t17.cloudfront.net
 
 # updates
 #softwareupdates.amazon.com


### PR DESCRIPTION
This domain is hit pretty hard by alexa devices. Speculation is that it is an analytics or tracking domain (https://www.reddit.com/r/pihole/comments/9470m2/anyone_know_what_httpd3p8zr0ffa9t17cloudfrontnet/). 

I have not noticed any issues after blocking it.