### PR TITLE
Add TheTake.ai to SmartTV

### DIFF
--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -1,5 +1,5 @@
 ! Title: Smart-TV Blocklist for AdGuard Home (by Dandelion Sprout's)
-! Version: 16December2021v1
+! Version: 6March2022v1
 ! Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 ! Please help to collect domains!
 ! It could occur that the TV fails to receive new updates, or that other apps or services no longer work. Please report such an incident.
@@ -191,6 +191,7 @@
 ||tv-static.scdn.co^
 !tv.deezer.com # Breaks Deezer's smart-TV apps.
 ||xml.opera.com^$ctag=device_tv
+||api.thetake.com^ # https://thetake.ai/
 
 ! Netflix
 ! secure., api-global., and appboot. break Netflix

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -1,5 +1,5 @@
 # Title: Smart-TV Blocklist for Pi-hole
-# Version: 15December2021v1
+# Version: 6March2022v1
 # Description: This is a blocklist to block smart-TVs sending metadata back home, sometimes with the added benefit of blocking interface ads for apps and movie services.
 # Please help with collecting domains!
 # It could occur that the TV fails to receive new updates, or that other apps or services no longer work. Please report such an incident.
@@ -274,6 +274,7 @@ trvdp.com
 tv-static.scdn.co
 #tv.deezer.com # Breaks Deezer's smart-TV apps.
 xml.opera.com
+api.thetake.com # https://thetake.ai/
 
 # Netflix
 # secure, api-global, and appboot break Netflix


### PR DESCRIPTION
Discovered outbound requests to api.thetake.com coming from my LG TV (requests happen every few minutes).

https://thetake.com redirects to https://thetake.ai/. This seems quite non-essential. According to their website, Samsung might be using this technology as well. This block has been tested for 1 week without issues.