### PR TITLE
Remove too general rule

### DIFF
--- a/SmartTV-AGH.txt
+++ b/SmartTV-AGH.txt
@@ -57,8 +57,6 @@
 ||smartshare.lgtvsdp.com^
 ||rdx2.lgtvsdp.com^
 ||lgtvcommon.com^
-! For TVs that try to connect to several garbled letter combinations
-/^[a-z]{7,10}$/$ctag=device_tv
 ! Used in malware exploits
 ||aic-ngfts.lge.com^
 


### PR DESCRIPTION
This blocks all internal hostnames such as `raspberrypi` or `myspecialserver` and shouldn't be used.

I also don't understand what the actual rule is supposed to do, i.e. "connect to several garbled letter combinations". I don't think that LG TVs just connect to "goobledidock", but rather to some .com domain name?