### PR TITLE
SmartTV.txt: add missing audited LG webOS telemetry/ad domains

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -373,6 +373,22 @@ yt.nextlgsdp.com
 za.nextlgsdp.com
 zm.nextlgsdp.com
 zw.nextlgsdp.com
+ads.lgtvcommon.com
+adsdtvc.com
+cdpbeacon.lgtvcommon.com
+de.emp.lgsmartplatform.com
+de.info.lgsmartad.com
+eic.api.lgtviot.com
+eic.lgtviot.com
+eic.nudge.lgtvcommon.com
+eic.tv.wiselg.com
+eic.wiseconfig.lgtvcommon.com
+homeprv.lgtvcommon.com
+initscr.lge.com
+lgsmartad.com
+lgtvsdp.com
+recommend.lgtvcommon.com
+smart.adtvc.app
 
 
 # Philips

--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -373,9 +373,6 @@ yt.nextlgsdp.com
 za.nextlgsdp.com
 zm.nextlgsdp.com
 zw.nextlgsdp.com
-ads.lgtvcommon.com
-adsdtvc.com
-cdpbeacon.lgtvcommon.com
 de.emp.lgsmartplatform.com
 de.info.lgsmartad.com
 eic.api.lgtviot.com
@@ -383,12 +380,8 @@ eic.lgtviot.com
 eic.nudge.lgtvcommon.com
 eic.tv.wiselg.com
 eic.wiseconfig.lgtvcommon.com
-homeprv.lgtvcommon.com
-initscr.lge.com
 lgsmartad.com
 lgtvsdp.com
-recommend.lgtvcommon.com
-smart.adtvc.app
 
 
 # Philips


### PR DESCRIPTION
Thanks for maintaining this list — it's the go-to Smart TV blocklist for Pi-hole users.

I run a dedicated LG webOS audit project: https://github.com/furkan-bayrak/lg-tv-blocklist — a two-week audit of a rooted LG G1 (44.8k-packet capture, 267k-query DNS log) with per-domain evidence. All domains below are from our SAFE tier: blocked live since early September, no breakage observed (LG store, app updates, logins, Netflix/Prime/HBO/YouTube tested).

I diffed against current master; these are not already present:

de.emp.lgsmartplatform.com
de.info.lgsmartad.com
eic.api.lgtviot.com
eic.lgtviot.com
eic.nudge.lgtvcommon.com
eic.tv.wiselg.com
eic.wiseconfig.lgtvcommon.com
lgsmartad.com
lgtvsdp.com

Notes:
- us.lgtvsdp.com is intentionally not re-added — I saw it's commented out with #117 (auto date/time). Our G1 tests showed no issue with it, but happy to share data if you ever want to revisit.
- ad.lgappstv.com and the nextlgsdp ccTLD block are already present, so they're not repeated here.
- If you'd like, I can also mirror these into SmartTV-AGH.txt, and/or add a one-line source comment in the LG section.
- Before finalizing, I re-verified DNS resolution for the audit set: 7 additional candidates currently return NXDOMAIN, so I trimmed them to keep only live entries.

PS: the file's version header still reads 13July2023v1 — happy to bump that in this PR too if useful.
