### PR TITLE
SmartTV.txt: add LG webOS rdth.lgtvcommon.com telemetry endpoints

### DIFF
--- a/SmartTV.txt
+++ b/SmartTV.txt
@@ -116,6 +116,8 @@ us.cdpsvc.lgtvcommon.com
 us.homeprv.lgtvcommon.com
 us.nudge.lgtvcommon.com
 us.rdl.lgtvcommon.com
+rdth.lgtvcommon.com
+us.rdth.lgtvcommon.com
 us.recommend.lgtvcommon.com
 us.lgsmartad.com
 us.service.lgtvcommon.com


### PR DESCRIPTION
### Summary

Adds missing LG webOS Remote Diagnostics & Telemetry Handler endpoints:
- `rdth.lgtvcommon.com`
- `us.rdth.lgtvcommon.com`

### Context & Evidence
- On modern LG webOS TVs (webOS 22 / C-series), `rdth.lgtvcommon.com` is actively polled to report diagnostic event telemetry back to LG's backend.
- It directly pairs with the existing `us.rdl.lgtvcommon.com` and `aic.rdl.lgtvcommon.com` (Remote Diagnostic Logging) entries already present in `SmartTV.txt`.
- **Testing:** Verified blocked on webOS with zero impact on the LG Content Store, app updates, or streaming apps (Netflix, YouTube, Prime).